### PR TITLE
Fix NPE in NonconfigurableAttributeMapper

### DIFF
--- a/src/main/java/com/google/devtools/build/lib/packages/NonconfigurableAttributeMapper.java
+++ b/src/main/java/com/google/devtools/build/lib/packages/NonconfigurableAttributeMapper.java
@@ -42,8 +42,9 @@ public class NonconfigurableAttributeMapper extends AbstractAttributeMapper {
 
   @Override
   public <T> T get(String attributeName, com.google.devtools.build.lib.syntax.Type<T> type) {
+    T attr = super.get(attributeName, type);
     Preconditions.checkState(!getAttributeDefinition(attributeName).isConfigurable(),
         "Attribute '%s' is potentially configurable - not allowed here", attributeName);
-    return super.get(attributeName, type);
+    return attr;
   }
 }


### PR DESCRIPTION
This PR fixes: https://github.com/bazelbuild/bazel/issues/2036 to provide more error message

without the fix:
```
java.lang.RuntimeException: Unrecoverable error while evaluating node 'CONFIGURED_TARGET:@grpc//:grpc++_config_proto 05cc524e2c4b9309660fb7daa4e35db9 (1333167441 455593757)' (requested by nodes 'CONFIGURED_TARGET:@grpc//:grpc_plugin_support 05cc524e2c4b9309660fb7daa4e35db9 (136418248 455593757)')
	at com.google.devtools.build.skyframe.ParallelEvaluator$Evaluate.run(ParallelEvaluator.java:429)
	at com.google.devtools.build.lib.concurrent.AbstractQueueVisitor$WrappedRunnable.run(AbstractQueueVisitor.java:501)
	at java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1142)
	at java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:617)
	at java.lang.Thread.run(Thread.java:745)
Caused by: java.lang.NullPointerException
	at com.google.devtools.build.lib.packages.NonconfigurableAttributeMapper.get(NonconfigurableAttributeMapper.java:45)
	at com.google.devtools.build.lib.bazel.rules.BazelRuleClassProvider$BazelPrerequisiteValidator.isTestOnlyRule(BazelRuleClassProvider.java:268)
	at com.google.devtools.build.lib.bazel.rules.BazelRuleClassProvider$BazelPrerequisiteValidator.validateDirectPrerequisiteForTestOnly(BazelRuleClassProvider.java:254)
	at com.google.devtools.build.lib.bazel.rules.BazelRuleClassProvider$BazelPrerequisiteValidator.validate(BazelRuleClassProvider.java:190)
	at com.google.devtools.build.lib.analysis.RuleContext$Builder.validateDirectPrerequisite(RuleContext.java:1937)
	at com.google.devtools.build.lib.analysis.RuleContext$Builder.createTargetMap(RuleContext.java:1610)
	at com.google.devtools.build.lib.analysis.RuleContext$Builder.build(RuleContext.java:1449)
	at com.google.devtools.build.lib.analysis.ConfiguredTargetFactory.createRule(ConfiguredTargetFactory.java:241)
	at com.google.devtools.build.lib.analysis.ConfiguredTargetFactory.createConfiguredTarget(ConfiguredTargetFactory.java:171)
	at com.google.devtools.build.lib.skyframe.SkyframeBuildView.createConfiguredTarget(SkyframeBuildView.java:491)
	at com.google.devtools.build.lib.skyframe.ConfiguredTargetFunction.createConfiguredTarget(ConfiguredTargetFunction.java:1024)
	at com.google.devtools.build.lib.skyframe.ConfiguredTargetFunction.compute(ConfiguredTargetFunction.java:249)
	at com.google.devtools.build.skyframe.ParallelEvaluator$Evaluate.run(ParallelEvaluator.java:370)
	... 4 more
java.lang.RuntimeException: Unrecoverable error while evaluating node 'CONFIGURED_TARGET:@grpc//:grpc++_config_proto 05cc524e2c4b9309660fb7daa4e35db9 (1333167441 455593757)' (requested by nodes 'CONFIGURED_TARGET:@grpc//:grpc_plugin_support 05cc524e2c4b9309660fb7daa4e35db9 (136418248 455593757)')
	at com.google.devtools.build.skyframe.ParallelEvaluator$Evaluate.run(ParallelEvaluator.java:429)
	at com.google.devtools.build.lib.concurrent.AbstractQueueVisitor$WrappedRunnable.run(AbstractQueueVisitor.java:501)
	at java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1142)
	at java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:617)
	at java.lang.Thread.run(Thread.java:745)
Caused by: java.lang.NullPointerException
	at com.google.devtools.build.lib.packages.NonconfigurableAttributeMapper.get(NonconfigurableAttributeMapper.java:45)
	at com.google.devtools.build.lib.bazel.rules.BazelRuleClassProvider$BazelPrerequisiteValidator.isTestOnlyRule(BazelRuleClassProvider.java:268)
	at com.google.devtools.build.lib.bazel.rules.BazelRuleClassProvider$BazelPrerequisiteValidator.validateDirectPrerequisiteForTestOnly(BazelRuleClassProvider.java:254)
	at com.google.devtools.build.lib.bazel.rules.BazelRuleClassProvider$BazelPrerequisiteValidator.validate(BazelRuleClassProvider.java:190)
	at com.google.devtools.build.lib.analysis.RuleContext$Builder.validateDirectPrerequisite(RuleContext.java:1937)
	at com.google.devtools.build.lib.analysis.RuleContext$Builder.createTargetMap(RuleContext.java:1610)
	at com.google.devtools.build.lib.analysis.RuleContext$Builder.build(RuleContext.java:1449)
	at com.google.devtools.build.lib.analysis.ConfiguredTargetFactory.createRule(ConfiguredTargetFactory.java:241)
	at com.google.devtools.build.lib.analysis.ConfiguredTargetFactory.createConfiguredTarget(ConfiguredTargetFactory.java:171)
	at com.google.devtools.build.lib.skyframe.SkyframeBuildView.createConfiguredTarget(SkyframeBuildView.java:491)
	at com.google.devtools.build.lib.skyframe.ConfiguredTargetFunction.createConfiguredTarget(ConfiguredTargetFunction.java:1024)
	at com.google.devtools.build.lib.skyframe.ConfiguredTargetFunction.compute(ConfiguredTargetFunction.java:249)
	at com.google.devtools.build.skyframe.ParallelEvaluator$Evaluate.run(ParallelEvaluator.java:370)
	... 4 more
```

with this fix:
```
java.lang.RuntimeException: Unrecoverable error while evaluating node 'CONFIGURED_TARGET:@grpc//:grpc++_config_proto 26809c5247f58eb7a6314bd0e13655a1 (1551360347 275342100)' (requested by nodes 'CONFIGURED_TARGET:@grpc//:grpc_plugin_support 26809c5247f58eb7a6314bd0e13655a1 (859246773 275342100)')
	at com.google.devtools.build.skyframe.ParallelEvaluator$Evaluate.run(ParallelEvaluator.java:438)
	at com.google.devtools.build.lib.concurrent.AbstractQueueVisitor$WrappedRunnable.run(AbstractQueueVisitor.java:501)
	at java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1142)
	at java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:617)
	at java.lang.Thread.run(Thread.java:745)
Caused by: java.lang.IllegalArgumentException: No such attribute testonly in rule protobuf_archive
	at com.google.devtools.build.lib.packages.AbstractAttributeMapper.getIndexWithTypeCheck(AbstractAttributeMapper.java:228)
	at com.google.devtools.build.lib.packages.AbstractAttributeMapper.get(AbstractAttributeMapper.java:57)
	at com.google.devtools.build.lib.packages.NonconfigurableAttributeMapper.get(NonconfigurableAttributeMapper.java:45)
	at com.google.devtools.build.lib.bazel.rules.BazelRuleClassProvider$BazelPrerequisiteValidator.isTestOnlyRule(BazelRuleClassProvider.java:266)
	at com.google.devtools.build.lib.bazel.rules.BazelRuleClassProvider$BazelPrerequisiteValidator.validateDirectPrerequisiteForTestOnly(BazelRuleClassProvider.java:252)
	at com.google.devtools.build.lib.bazel.rules.BazelRuleClassProvider$BazelPrerequisiteValidator.validate(BazelRuleClassProvider.java:196)
	at com.google.devtools.build.lib.analysis.RuleContext$Builder.validateDirectPrerequisite(RuleContext.java:1954)
	at com.google.devtools.build.lib.analysis.RuleContext$Builder.createTargetMap(RuleContext.java:1626)
	at com.google.devtools.build.lib.analysis.RuleContext$Builder.build(RuleContext.java:1465)
	at com.google.devtools.build.lib.analysis.ConfiguredTargetFactory.createRule(ConfiguredTargetFactory.java:245)
	at com.google.devtools.build.lib.analysis.ConfiguredTargetFactory.createConfiguredTarget(ConfiguredTargetFactory.java:176)
	at com.google.devtools.build.lib.skyframe.SkyframeBuildView.createConfiguredTarget(SkyframeBuildView.java:491)
	at com.google.devtools.build.lib.skyframe.ConfiguredTargetFunction.createConfiguredTarget(ConfiguredTargetFunction.java:1094)
	at com.google.devtools.build.lib.skyframe.ConfiguredTargetFunction.compute(ConfiguredTargetFunction.java:251)
	at com.google.devtools.build.skyframe.ParallelEvaluator$Evaluate.run(ParallelEvaluator.java:373)
	... 4 more
java.lang.RuntimeException: Unrecoverable error while evaluating node 'CONFIGURED_TARGET:@grpc//:grpc++_config_proto 26809c5247f58eb7a6314bd0e13655a1 (1551360347 275342100)' (requested by nodes 'CONFIGURED_TARGET:@grpc//:grpc_plugin_support 26809c5247f58eb7a6314bd0e13655a1 (859246773 275342100)')
	at com.google.devtools.build.skyframe.ParallelEvaluator$Evaluate.run(ParallelEvaluator.java:438)
	at com.google.devtools.build.lib.concurrent.AbstractQueueVisitor$WrappedRunnable.run(AbstractQueueVisitor.java:501)
	at java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1142)
	at java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:617)
	at java.lang.Thread.run(Thread.java:745)
Caused by: java.lang.IllegalArgumentException: No such attribute testonly in rule protobuf_archive
	at com.google.devtools.build.lib.packages.AbstractAttributeMapper.getIndexWithTypeCheck(AbstractAttributeMapper.java:228)
	at com.google.devtools.build.lib.packages.AbstractAttributeMapper.get(AbstractAttributeMapper.java:57)
	at com.google.devtools.build.lib.packages.NonconfigurableAttributeMapper.get(NonconfigurableAttributeMapper.java:45)
	at com.google.devtools.build.lib.bazel.rules.BazelRuleClassProvider$BazelPrerequisiteValidator.isTestOnlyRule(BazelRuleClassProvider.java:266)
	at com.google.devtools.build.lib.bazel.rules.BazelRuleClassProvider$BazelPrerequisiteValidator.validateDirectPrerequisiteForTestOnly(BazelRuleClassProvider.java:252)
	at com.google.devtools.build.lib.bazel.rules.BazelRuleClassProvider$BazelPrerequisiteValidator.validate(BazelRuleClassProvider.java:196)
	at com.google.devtools.build.lib.analysis.RuleContext$Builder.validateDirectPrerequisite(RuleContext.java:1954)
	at com.google.devtools.build.lib.analysis.RuleContext$Builder.createTargetMap(RuleContext.java:1626)
	at com.google.devtools.build.lib.analysis.RuleContext$Builder.build(RuleContext.java:1465)
	at com.google.devtools.build.lib.analysis.ConfiguredTargetFactory.createRule(ConfiguredTargetFactory.java:245)
	at com.google.devtools.build.lib.analysis.ConfiguredTargetFactory.createConfiguredTarget(ConfiguredTargetFactory.java:176)
	at com.google.devtools.build.lib.skyframe.SkyframeBuildView.createConfiguredTarget(SkyframeBuildView.java:491)
	at com.google.devtools.build.lib.skyframe.ConfiguredTargetFunction.createConfiguredTarget(ConfiguredTargetFunction.java:1094)
	at com.google.devtools.build.lib.skyframe.ConfiguredTargetFunction.compute(ConfiguredTargetFunction.java:251)
	at com.google.devtools.build.skyframe.ParallelEvaluator$Evaluate.run(ParallelEvaluator.java:373)
	... 4 more
```